### PR TITLE
Fix property name typo

### DIFF
--- a/src/workflow/agents/WindsurfAgent.test.ts
+++ b/src/workflow/agents/WindsurfAgent.test.ts
@@ -31,7 +31,7 @@ describe('WindsurfAgent', () => {
 
   describe('getForecast', () => {
     it('should return a forecast from the mock API', async () => {
-      const mockForecast: WindForecast = { spotId: 'test-spot', time: new Date(), windSpeedKots: 18, windDirection: 270 };
+      const mockForecast: WindForecast = { spotId: 'test-spot', time: new Date(), windSpeedKnots: 18, windDirection: 270 };
       mockedAjax.mockReturnValue(of({ response: mockForecast }));
 
       const result = await new Promise((resolve: (value: WindForecast | null) => void) => agent.getForecast('test-spot', new Date()).subscribe(resolve));
@@ -52,14 +52,14 @@ describe('WindsurfAgent', () => {
 
   describe('recommendGear', () => {
     it('should recommend a small sail and board for strong wind', () => {
-      const strongWind: WindForecast = { spotId: 'any', time: new Date(), windSpeedKots: 25, windDirection: 300 };
+      const strongWind: WindForecast = { spotId: 'any', time: new Date(), windSpeedKnots: 25, windDirection: 300 };
       const recommendation: RecommendedGear = agent.recommendGear(riderProfile, strongWind);
       expect(recommendation.sailSizeSqm).toBeCloseTo(3.6);
       expect(recommendation.boardVolumeLiters).toBe(95);
     });
 
     it('should recommend a large sail and board for light wind', () => {
-      const lightWind: WindForecast = { spotId: 'any', time: new Date(), windSpeedKots: 15, windDirection: 180 };
+      const lightWind: WindForecast = { spotId: 'any', time: new Date(), windSpeedKnots: 15, windDirection: 180 };
       const recommendation: RecommendedGear = agent.recommendGear(riderProfile, lightWind);
       expect(recommendation.sailSizeSqm).toBe(6);
       expect(recommendation.boardVolumeLiters).toBe(95);

--- a/src/workflow/agents/WindsurfAgent.ts
+++ b/src/workflow/agents/WindsurfAgent.ts
@@ -21,7 +21,7 @@ export interface GeoCoordinates {
 export interface WindForecast {
   spotId: string;
   time: Date;
-  windSpeedKots: number;
+  windSpeedKnots: number;
   windDirection: number; // In degrees
   waveHeightMeters?: number;
 }
@@ -69,7 +69,7 @@ export class WindsurfAgent {
     const mockApiCall$ = of({
       spotId,
       time,
-      windSpeedKots: 18,
+      windSpeedKnots: 18,
       windDirection: 270, // West
       waveHeightMeters: 1.2,
     }).pipe(
@@ -94,9 +94,9 @@ export class WindsurfAgent {
    */
   recommendGear(riderProfile: RiderProfile, forecast: WindForecast): RecommendedGear {
     // Simplified logic placeholder
-    const sailSize = riderProfile.skillLevel === 'beginner' 
-      ? Math.round(75 / forecast.windSpeedKots) 
-      : Math.round(90 / forecast.windSpeedKots);
+    const sailSize = riderProfile.skillLevel === 'beginner'
+      ? Math.round(75 / forecast.windSpeedKnots)
+      : Math.round(90 / forecast.windSpeedKnots);
       
     const boardVolume = riderProfile.weightKg + (riderProfile.skillLevel === 'beginner' ? 40 : 15);
 

--- a/src/workflow/nodes/windForecastNode.tsx
+++ b/src/workflow/nodes/windForecastNode.tsx
@@ -39,7 +39,7 @@ const WindForecastNode = ({ data }: { data: any }) => {
       </label>
       {forecastResult && (
         <div style={{ marginTop: '10px', background: '#F3F3F3', padding: '8px', borderRadius: '4px' }}>
-          <div><strong>Wind:</strong> {forecastResult.windSpeedKots} kts</div>
+          <div><strong>Wind:</strong> {forecastResult.windSpeedKnots} kts</div>
           <div><strong>Direction:</strong> {forecastResult.windDirection}°</div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- rename `windSpeedKots` to `windSpeedKnots`

## Testing
- `npm test` *(fails: OpenAI key not configured, etc.)*
- `npm run lint` *(fails: 510 problems)*

------
https://chatgpt.com/codex/tasks/task_e_687294d83df883239c06575b3be6c45c