### PR TITLE
feat: add vision scheduler and percept utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist-ssr
 
 # Environment variables
 # .env
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "@vitest/coverage-v8": "^3.2.4",
     "axios": "1.6.7",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/src/vision/scheduler/VisionScheduler.ts
+++ b/src/vision/scheduler/VisionScheduler.ts
@@ -1,0 +1,61 @@
+export type VisionTask = 'face' | 'object' | 'text' | 'pose';
+
+export interface VisionSchedulerOptions {
+  maxGPUTimeMs: number;
+}
+
+export interface VisionProvider {
+  name: string;
+  detect(task: VisionTask, frame: VideoFrame): Promise<number>;
+}
+
+interface ScheduledTask {
+  task: VisionTask;
+  priority: number;
+  deadline: number;
+}
+
+export class VisionScheduler {
+  private queue: ScheduledTask[] = [];
+  private providers = new Map<VisionTask, { provider: VisionProvider; cost: number }>();
+  private running = false;
+
+  constructor(private opts: VisionSchedulerOptions) {}
+
+  register(provider: VisionProvider, costMs: number): void {
+    this.providers.set(provider.name as VisionTask, { provider, cost: costMs });
+  }
+
+  request(task: VisionTask, priority = 0): void {
+    this.queue.push({ task, priority, deadline: performance.now() });
+  }
+
+  start(): void {
+    this.running = true;
+    requestAnimationFrame(this.step);
+  }
+
+  stop(): void {
+    this.running = false;
+  }
+
+  private step = () => {
+    if (!this.running) return;
+    const frameStart = performance.now();
+    let budget = this.opts.maxGPUTimeMs;
+    while (budget > 0 && this.queue.length) {
+      const job = this.queue.shift()!;
+      const providerInfo = this.providers.get(job.task);
+      if (!providerInfo) continue;
+      if (providerInfo.cost > budget) break;
+      budget -= providerInfo.cost;
+      providerInfo.provider.detect(job.task, new VideoFrame(document.createElement('canvas')));
+    }
+    const elapsed = performance.now() - frameStart;
+    if (elapsed < this.opts.maxGPUTimeMs) {
+      requestAnimationFrame(this.step);
+    } else {
+      setTimeout(() => requestAnimationFrame(this.step), 0);
+    }
+  };
+}

--- a/src/vision/types/Percept.ts
+++ b/src/vision/types/Percept.ts
@@ -1,0 +1,11 @@
+export interface Percept {
+  type: 'face' | 'object' | 'text' | 'pose';
+  source: string;
+  ts: number;
+  normX: number;
+  normY: number;
+  z?: number;
+  orientation?: number;
+  space: 'image' | 'world';
+  payload: unknown;
+}

--- a/src/vision/utils/coords.ts
+++ b/src/vision/utils/coords.ts
@@ -1,0 +1,10 @@
+import { Percept } from '../types/Percept';
+
+export function toBBox(p: Percept) {
+  const size = 0.1;
+  return new DOMRect(p.normX - size / 2, p.normY - size / 2, size, size);
+}
+
+export function toLandmarks(p: Percept) {
+  return [{ x: p.normX, y: p.normY, z: p.z ?? 0 }];
+}

--- a/tests/vision/VisionScheduler.test.ts
+++ b/tests/vision/VisionScheduler.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { VisionScheduler, VisionProvider } from '../../src/vision/scheduler/VisionScheduler';
+
+const createProvider = (name: string) => {
+  return {
+    name,
+    detect: vi.fn().mockResolvedValue(0),
+  } as unknown as VisionProvider;
+};
+
+describe('VisionScheduler', () => {
+  it('does not exceed GPU time budget', async () => {
+    const sched = new VisionScheduler({ maxGPUTimeMs: 5 });
+    const p1 = createProvider('face');
+    const p2 = createProvider('object');
+    const p3 = createProvider('text');
+    sched.register(p1, 2);
+    sched.register(p2, 2);
+    sched.register(p3, 2);
+
+    sched.request('face');
+    sched.request('object');
+    sched.request('text');
+
+    sched.start();
+
+    await new Promise((r) => setTimeout(r, 10));
+    sched.stop();
+
+    const calls = (p1.detect as any).mock.calls.length + (p2.detect as any).mock.calls.length + (p3.detect as any).mock.calls.length;
+    expect(calls).toBeLessThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `VisionScheduler` with a simple budget mechanism
- introduce `Percept` type for unified spatial markers
- add coordinate helpers in `coords.ts`
- add unit test for scheduler
- add coverage dependency

## Testing
- `pnpm install`
- `pnpm lint` *(fails: many lint errors)*
- `pnpm test --coverage` *(fails: vitest execution errors)*
- `pnpm build` *(fails: build error in vite)*
- `pnpm run preview` *(fails: dist missing)*
- `npx playwright test` *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68749713297c8323b5e230f0d23b5908