### PR TITLE
Implement agent memory limits and concurrency locks

### DIFF
--- a/src/agents/AgentCommunicationManager.ts
+++ b/src/agents/AgentCommunicationManager.ts
@@ -1,0 +1,25 @@
+export class AgentCommunicationManager {
+  private locks: Map<string, Promise<void>> = new Map();
+
+  async executeWithLock<T>(agentName: string, fn: () => Promise<T>): Promise<T> {
+    while (this.locks.has(agentName)) {
+      await this.locks.get(agentName);
+    }
+
+    let release: () => void;
+    const lockPromise = new Promise<void>(resolve => {
+      release = resolve;
+    });
+
+    this.locks.set(agentName, lockPromise);
+
+    try {
+      return await fn();
+    } finally {
+      this.locks.delete(agentName);
+      release!();
+    }
+  }
+}
+
+export const agentCommunicationManager = new AgentCommunicationManager();

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -15,6 +15,8 @@ import { RosAgent } from './RosAgent';
 class AgentRegistry {
   private static instance: AgentRegistry;
   private agents: Map<string, BaseAgent> = new Map();
+  private lastAccess: Map<string, number> = new Map();
+  private maxAgents = 50;
 
   // Private constructor to prevent direct instantiation.
   private constructor() {}
@@ -39,7 +41,11 @@ class AgentRegistry {
       console.warn(`Agent with name "${agent.name}" is already registered.`);
       return;
     }
+    if (this.agents.size >= this.maxAgents) {
+      this.cleanupOldAgents();
+    }
     this.agents.set(agent.name, agent);
+    this.lastAccess.set(agent.name, Date.now());
   }
 
   /**
@@ -48,7 +54,11 @@ class AgentRegistry {
    * @returns The agent instance, or undefined if not found.
    */
   public getAgent(name: string): BaseAgent | undefined {
-    return this.agents.get(name);
+    const agent = this.agents.get(name);
+    if (agent) {
+      this.lastAccess.set(name, Date.now());
+    }
+    return agent;
   }
 
   /**
@@ -63,6 +73,19 @@ class AgentRegistry {
    */
   public listAgents(): BaseAgent[] {
     return Array.from(this.agents.values());
+  }
+
+  /**
+   * Removes the least recently accessed agents when maximum capacity is reached.
+   */
+  private cleanupOldAgents(): void {
+    const sorted = Array.from(this.lastAccess.entries()).sort((a, b) => a[1] - b[1]);
+    const toRemove = Math.floor(this.maxAgents * 0.1);
+    for (let i = 0; i < toRemove && i < sorted.length; i++) {
+      const [name] = sorted[i];
+      this.agents.delete(name);
+      this.lastAccess.delete(name);
+    }
   }
 }
 

--- a/tests/agents/communicationManager.test.ts
+++ b/tests/agents/communicationManager.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { AgentCommunicationManager } from '../../src/agents/AgentCommunicationManager';
+
+
+describe('AgentCommunicationManager', () => {
+  it('serializes calls for the same agent', async () => {
+    const manager = new AgentCommunicationManager();
+    const order: string[] = [];
+
+    const task = (id: string) => manager.executeWithLock('A', async () => {
+      order.push(id + 'start');
+      await new Promise(r => setTimeout(r, 10));
+      order.push(id + 'end');
+    });
+
+    await Promise.all([task('1'), task('2')]);
+    expect(order).toEqual(['1start', '1end', '2start', '2end']);
+  });
+});

--- a/tests/agents/registryMemory.test.ts
+++ b/tests/agents/registryMemory.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import AgentRegistry from '../../src/agents/AgentRegistry';
+import type { BaseAgent, AgentExecuteProps, AgentExecuteResult } from '../../src/agents/types';
+import { AgentDomains } from '../../src/agents/types';
+
+class DummyAgent implements BaseAgent {
+  constructor(public name: string) {}
+  description = 'dummy';
+  version = '1.0';
+  domain = AgentDomains.KNOWLEDGE;
+  capabilities: string[] = [];
+  async execute(_props: AgentExecuteProps): Promise<AgentExecuteResult> {
+    return { success: true, output: null };
+  }
+}
+
+describe('AgentRegistry memory management', () => {
+  it('limits number of agents and cleans old ones', () => {
+    const registry: any = new (AgentRegistry as any)();
+    for (let i = 0; i < 55; i++) {
+      registry.register(new DummyAgent('A' + i));
+    }
+    expect(registry.getAllAgents().length).toBeLessThanOrEqual(50);
+  });
+
+  it('updates last access on retrieval', async () => {
+    const registry: any = new (AgentRegistry as any)();
+    const agent = new DummyAgent('One');
+    registry.register(agent);
+    const first = registry.lastAccess.get('One');
+    await new Promise(r => setTimeout(r, 5));
+    registry.getAgent('One');
+    const second = registry.lastAccess.get('One');
+    expect(second).toBeGreaterThan(first);
+  });
+});


### PR DESCRIPTION
## Summary
- add `AgentCommunicationManager` with an execute lock
- limit `AgentRegistry` size and clean up least used agents
- track last access time of registered agents
- add regression tests

## Testing
- `npm test --silent` *(fails: 29 failed, 12 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6874b920fd5083239a806883c14fd6b1