### PR TITLE
Improve service worker caching with offline fallback

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Offline</title>
+    <style>
+      body { display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; font-family: sans-serif; background: #f0f0f0; }
+      h1 { color: #333; }
+    </style>
+  </head>
+  <body>
+    <h1>You are offline. Please check your connection.</h1>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- include offline page in service worker cache list
- add offline.html fallback page
- enhance fetch handler to cache successful requests and return offline page on network errors

## Testing
- `npm test` *(fails: 41 failed, 77 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6874c9a89bc08323b54c94d2a0f9df3b