### PR TITLE
Improve token security and add agent timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ npm i @picovoice/porcupine-web @picovoice/web-voice-processor
 4. (Optionnel) Pour un mot-clé personnalisé, placez le fichier `lisa.ppn` dans `public/porcupine/` et remplacez `BuiltInKeyword.PORCUPINE` par le chemin du modèle dans `useWakeWord.ts`.
 
 ### Sécurité
-- Le jeton Google OAuth est désormais stocké dans **`sessionStorage`** (au lieu de `localStorage`) et sera purgé à la fermeture de l'onglet.
+- Le jeton Google OAuth est désormais chiffré et stocké dans **`sessionStorage`** via `SecureTokenStorage`, puis purgé à la fermeture de l'onglet.
 - Un **Content-Security-Policy** strict est injecté via un plugin Vite (`csp-headers`). Vous pouvez l'ajuster dans `vite.config.ts`.
 - Les appels MCP utilisent un en-tête `Authorization: Bearer <VITE_MCP_TOKEN>` si la variable est définie.
 - Les notifications push utilisent un **Service Worker** conforme aux bonnes pratiques de sécurité.

--- a/src/agents/AgentRegistry.ts
+++ b/src/agents/AgentRegistry.ts
@@ -85,7 +85,14 @@ class AgentRegistry {
         error: `Agent ${name} not found`
       };
     }
-    return await agent.execute(props);
+
+    const timeout = props.timeout ?? 30000;
+    return Promise.race([
+      agent.execute(props),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('Agent timeout')), timeout)
+      )
+    ]);
   }
 
   /**

--- a/src/agents/CalendarAgent.ts
+++ b/src/agents/CalendarAgent.ts
@@ -15,6 +15,7 @@ import type {
   BaseAgent
 } from './types';
 import { agentRegistry } from './registry';
+import { secureTokenStorage } from '../utils/secureTokenStorage';
 
 /**
  * Supported calendar intents
@@ -101,8 +102,8 @@ export interface CalendarEvent {
  * Helper function to get auth token from session storage
  * This is a temporary solution. In the future, the agent should handle its own auth.
  */
-function getAuthToken(): string | null {
-  return sessionStorage.getItem('google_access_token');
+async function getAuthToken(): Promise<string | null> {
+  return secureTokenStorage.getToken();
 }
 
 export class CalendarAgent implements BaseAgent {
@@ -181,7 +182,7 @@ export class CalendarAgent implements BaseAgent {
       }
 
       // Check authentication
-      const token = getAuthToken();
+      const token = await getAuthToken();
       if (!token) {
         return {
           success: false,
@@ -461,7 +462,7 @@ export class CalendarAgent implements BaseAgent {
    * Creates a new event in Google Calendar
    */
   private async createEvent(props: CalendarEvent): Promise<any> {
-    const token = getAuthToken();
+    const token = await getAuthToken();
     if (!token) return { success: false, error: 'Not authenticated', output: null };
 
     try {
@@ -506,7 +507,7 @@ export class CalendarAgent implements BaseAgent {
    * Deletes an event from Google Calendar
    */
   private async deleteEvent(eventId: string): Promise<any> {
-    const token = getAuthToken();
+    const token = await getAuthToken();
     if (!token) throw new Error('Not authenticated with Google Calendar');
     
     try {
@@ -538,7 +539,7 @@ export class CalendarAgent implements BaseAgent {
    * Updates an existing event in Google Calendar
    */
   private async updateEvent(eventId: string, eventData: Partial<CalendarEvent>): Promise<any> {
-    const token = getAuthToken();
+    const token = await getAuthToken();
     if (!token) throw new Error('Not authenticated with Google Calendar');
     
     try {
@@ -610,7 +611,7 @@ export class CalendarAgent implements BaseAgent {
    * Finds available time slots in the calendar
    */
   private async findAvailableTime(durationMinutes: number, date?: string): Promise<any> {
-    const token = getAuthToken();
+    const token = await getAuthToken();
     if (!token) throw new Error('Not authenticated with Google Calendar');
     
     try {
@@ -689,7 +690,7 @@ export class CalendarAgent implements BaseAgent {
    * Lists events from Google Calendar for a specified period
    */
   private async listEvents(props: { period: TimePeriod, startDate?: string, endDate?: string }): Promise<any> {
-    const token = getAuthToken();
+    const token = await getAuthToken();
     if (!token) throw new Error('Not authenticated with Google Calendar');
 
     try {

--- a/src/components/GoogleCalendarButton.tsx
+++ b/src/components/GoogleCalendarButton.tsx
@@ -24,8 +24,8 @@ export function GoogleCalendarButton() {
     }
   };
 
-  const handleSignOut = () => {
-    signOut();
+  const handleSignOut = async () => {
+    await signOut();
   };
 
   const upcomingEvents = events.slice(0, 3); // Show next 3 events

--- a/src/utils/secureTokenStorage.ts
+++ b/src/utils/secureTokenStorage.ts
@@ -1,0 +1,72 @@
+export class SecureTokenStorage {
+  private encryptionKey: CryptoKey | null = null;
+
+  async init() {
+    if (!this.encryptionKey) {
+      this.encryptionKey = await crypto.subtle.generateKey(
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['encrypt', 'decrypt']
+      );
+    }
+  }
+
+  async storeToken(token: string): Promise<void> {
+    if (!this.encryptionKey) {
+      await this.init();
+    }
+    const encrypted = await this.encrypt(token);
+    sessionStorage.setItem('google_access_token', encrypted);
+  }
+
+  async getToken(): Promise<string | null> {
+    if (!this.encryptionKey) {
+      await this.init();
+    }
+    const data = sessionStorage.getItem('google_access_token');
+    if (!data) return null;
+    try {
+      return await this.decrypt(data);
+    } catch {
+      return null;
+    }
+  }
+
+  removeToken(): void {
+    sessionStorage.removeItem('google_access_token');
+  }
+
+  private async encrypt(data: string): Promise<string> {
+    if (!this.encryptionKey) {
+      throw new Error('Encryption key not initialized');
+    }
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encoded = new TextEncoder().encode(data);
+    const encrypted = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      this.encryptionKey,
+      encoded
+    );
+    const combined = new Uint8Array(iv.length + encrypted.byteLength);
+    combined.set(iv);
+    combined.set(new Uint8Array(encrypted), iv.length);
+    return btoa(String.fromCharCode(...combined));
+  }
+
+  private async decrypt(data: string): Promise<string> {
+    if (!this.encryptionKey) {
+      throw new Error('Encryption key not initialized');
+    }
+    const combined = Uint8Array.from(atob(data), c => c.charCodeAt(0));
+    const iv = combined.slice(0, 12);
+    const encrypted = combined.slice(12);
+    const decrypted = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv },
+      this.encryptionKey,
+      encrypted
+    );
+    return new TextDecoder().decode(decrypted);
+  }
+}
+
+export const secureTokenStorage = new SecureTokenStorage();

--- a/tests/agents/timeout.test.ts
+++ b/tests/agents/timeout.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import AgentRegistry from '../../src/agents/AgentRegistry';
+import type { BaseAgent, AgentExecuteProps, AgentExecuteResult } from '../../src/agents/types';
+import { AgentDomains } from '../../src/agents/types';
+
+class SlowAgent implements BaseAgent {
+  name = 'SlowAgent';
+  description = 'slow';
+  version = '1.0';
+  domain = AgentDomains.KNOWLEDGE;
+  capabilities: string[] = [];
+  async execute(_props: AgentExecuteProps): Promise<AgentExecuteResult> {
+    await new Promise(r => setTimeout(r, 50));
+    return { success: true, output: null };
+  }
+}
+
+describe('AgentRegistry timeouts', () => {
+  it('should timeout if agent execution exceeds limit', async () => {
+    const registry: any = new (AgentRegistry as any)();
+    registry.register(new SlowAgent());
+    await expect(registry.execute('SlowAgent', { timeout: 10 })).rejects.toThrow('Agent timeout');
+  });
+});


### PR DESCRIPTION
## Summary
- encrypt Google OAuth token with `SecureTokenStorage`
- handle encrypted token in `useGoogleCalendar` and `CalendarAgent`
- enforce execution timeouts in `AgentRegistry`
- update Google Calendar button and tests
- document secure token storage in README
- add test for agent timeout

## Testing
- `npm run lint` *(fails: 638 problems)*
- `npm test` *(fails to run all tests)*

------
https://chatgpt.com/codex/tasks/task_e_6874e206722483238812f7ba65bc4a36